### PR TITLE
Functional academic_tracker endpoints

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: rails db:migrate

--- a/app/assets/stylesheets/academic_tracker.scss
+++ b/app/assets/stylesheets/academic_tracker.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AcademicTracker controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/academic_tracker_controller.rb
+++ b/app/controllers/academic_tracker_controller.rb
@@ -1,0 +1,10 @@
+class AcademicTrackerController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def edit
+  end
+end

--- a/app/helpers/academic_tracker_helper.rb
+++ b/app/helpers/academic_tracker_helper.rb
@@ -1,0 +1,2 @@
+module AcademicTrackerHelper
+end

--- a/app/views/academic_tracker/edit.html.erb
+++ b/app/views/academic_tracker/edit.html.erb
@@ -1,1 +1,1 @@
-<h1>ABB Member Academic Tracker Edit</h1>
+<h1>Academic Tracker /edit</h1>

--- a/app/views/academic_tracker/edit.html.erb
+++ b/app/views/academic_tracker/edit.html.erb
@@ -1,0 +1,1 @@
+<h1>ABB Member Academic Tracker Edit</h1>

--- a/app/views/academic_tracker/index.html.erb
+++ b/app/views/academic_tracker/index.html.erb
@@ -1,0 +1,1 @@
+<h1>ABB Member Academic Tracker Index</h1>

--- a/app/views/academic_tracker/index.html.erb
+++ b/app/views/academic_tracker/index.html.erb
@@ -1,1 +1,1 @@
-<h1>ABB Member Academic Tracker Index</h1>
+<h1>Academic Tracker index</h1>

--- a/app/views/academic_tracker/show.html.erb
+++ b/app/views/academic_tracker/show.html.erb
@@ -1,0 +1,1 @@
+<h1>ABB Member Academic Tracker Show</h1>

--- a/app/views/academic_tracker/show.html.erb
+++ b/app/views/academic_tracker/show.html.erb
@@ -1,1 +1,1 @@
-<h1>ABB Member Academic Tracker Show</h1>
+<h1>Academic Tracker /show</h1>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  resources :academic_tracker do 
+  end
 end

--- a/test/controllers/academic_tracker_controller_test.rb
+++ b/test/controllers/academic_tracker_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class AcademicTrackerControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get academic_tracker_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get academic_tracker_show_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get academic_tracker_edit_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Empty but working academic_tracker endpoints
/academic_tracker takes you to the index page and eventually will serve as a way to verify member access to view academic points
/academic_tracker/show currently empty but will allow users to view their academic points
/academic_tracker/edit currently empty but will allow admins to update user points